### PR TITLE
Exposed  env var in nimbus.yaml for tcp and udp

### DIFF
--- a/local/clients/nimbus.yaml
+++ b/local/clients/nimbus.yaml
@@ -12,6 +12,8 @@ services:
       --rest-port="$CCAPIPORT"
       --rest-address="0.0.0.0"
       --rest-allow-origin=*
+      --tcp-port=$CCPORT
+      --udp-port=$CCPORT
     env_file: "$DATA_DIR/nodeset.env"
     volumes:
       - "$DATA_DIR/nimbus-data:/home/user/data"


### PR DESCRIPTION
This change enables port changes on nimbus  when updating $CCPORT in nodeset.env.

I tested by updating the port to 9004

Befor change:
```
...
node-data-nimbus-1  | INF 2024-01-01 15:27:38.070+00:00 Listening to incoming network requests     topics="beacnde"
node-data-nimbus-1  | INF 2024-01-01 15:27:38.070+00:00 Starting discovery node                    topics="eth p2p discv5" node=61*30e497:unaddressable bindAddress=0.0.0.0:9000
...
```

After Change:
```
...
node-data-nimbus-1  | INF 2024-01-01 15:27:38.070+00:00 Listening to incoming network requests     topics="beacnde"
node-data-nimbus-1  | INF 2024-01-01 15:27:38.070+00:00 Starting discovery node                    topics="eth p2p discv5" node=61*30e497:unaddressable bindAddress=0.0.0.0:9004
...
```