### PR TITLE
Updated sw-operator to v2.1.2

### DIFF
--- a/shared/config/stakewise-config.go
+++ b/shared/config/stakewise-config.go
@@ -13,7 +13,7 @@ import (
 const (
 	// Tags
 	daemonTag   string = "nodeset/hyperdrive-stakewise:v" + shared.StakewiseVersion
-	operatorTag string = "europe-west4-docker.pkg.dev/stakewiselabs/public/v3-operator:v1.3.2"
+	operatorTag string = "europe-west4-docker.pkg.dev/stakewiselabs/public/v3-operator:v2.1.2"
 )
 
 // Configuration for Stakewise

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	StakewiseVersion string = "1.1.0-b1"
+	StakewiseVersion string = "1.1.0-dev"
 )


### PR DESCRIPTION
This bumps the StakeWise v3 operator version up to the latest.