### PR TITLE
Increase the delay during tasks ready checks

### DIFF
--- a/tasks/run.go
+++ b/tasks/run.go
@@ -17,8 +17,14 @@ import (
 
 // Config
 const (
+	// Time to wait after finishing tasks before starting the next iteration
 	tasksInterval time.Duration = time.Minute * 5
-	taskCooldown  time.Duration = time.Second * 10
+
+	// Time between individual tasks
+	taskCooldown time.Duration = time.Second
+
+	// Time to wait if the tasks loop isn't ready before checking again
+	notReadySleepTime time.Duration = time.Second * 15
 
 	ErrorColor             = color.FgRed
 	WarningColor           = color.FgYellow
@@ -210,10 +216,10 @@ func (t *TaskLoop) waitUntilReady() waitUntilReadyResult {
 	return waitUntilReadySuccess
 }
 
-// Sleep on the context for the task cooldown time, and return either exit or continue
+// Sleep on the context for the not-ready sleep time, and return either exit or continue
 // based on whether the context was cancelled.
 func (t *TaskLoop) sleepAndReturnReadyResult() waitUntilReadyResult {
-	if utils.SleepWithCancel(t.ctx, taskCooldown) {
+	if utils.SleepWithCancel(t.ctx, notReadySleepTime) {
 		return waitUntilReadyExit
 	} else {
 		return waitUntilReadyContinue


### PR DESCRIPTION
This bumps the ready check from 10 seconds to 15 seconds and reduces the time between tasks to 1 second so it has parity with Constellation.