### PR TITLE
Add a catch for the new 409 response

### DIFF
--- a/relay/validators.go
+++ b/relay/validators.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -315,6 +316,11 @@ func (h *baseHandler) getValidators(w http.ResponseWriter, r *http.Request) {
 	start = time.Now()
 	signatureResponse, err := hd.NodeSet_StakeWise.GetValidatorManagerSignature(res.DeploymentName, res.Vault, depositRoot, depositDatas, encryptedExits)
 	if err != nil {
+		// Manual handling of 409 since it was added after the daemon was tagged
+		if strings.Contains(err.Error(), "has already been assigned to a user recently") {
+			HandleError(w, logger, http.StatusConflict, fmt.Errorf("deposit root %s has already been used by another node operator", depositRoot.Hex()))
+			return
+		}
 		HandleError(w, logger, http.StatusInternalServerError, fmt.Errorf("error getting validators signature from nodeset: %w", err))
 		return
 	}


### PR DESCRIPTION
nodeset.io will now return a 409 if you request a signature against a deposit root that was already used by someone. Normally this would go in NCG but since the daemon was already tagged, this just provides some manual checking for the error message for now so it can provide a better error code to the SW Operator.